### PR TITLE
fetch events deleted

### DIFF
--- a/client/src/reducers/authReducer.js
+++ b/client/src/reducers/authReducer.js
@@ -2,8 +2,6 @@ import {FETCH_USER, FETCH_EVENTS} from '../actions/types';
 
 export default function (state = null, action) {
   switch (action.type) {
-  case FETCH_EVENTS:
-    return action.payload || false;
   case FETCH_USER:
     return action.payload || false;
   default:


### PR DESCRIPTION
The FETCH_EVENTS case was wrongly mentioned here, this action should not be handled by authReducer. This bug was introduced by the seed project I used.