### PR TITLE
Aditya patch #145

### DIFF
--- a/middlewares/joiValidator.mw.js
+++ b/middlewares/joiValidator.mw.js
@@ -8,10 +8,11 @@ const joiValidator = schema => (req, res, next) => {
   const schemaForRole = schema[role];
 
   const data = { ...req.query, ...req.params };
+
   const { error, value } = Joi.validate(data, schemaForRole);
   if (error) {
     return res.status(400).send({
-      error: `Invalid Request`
+      error: error.details[0].message
     });
   }
   req.items = value;

--- a/models/validations/common.joi.js
+++ b/models/validations/common.joi.js
@@ -12,7 +12,5 @@ module.exports = {
     .max(25)
     .required(),
   id: Joi.string().required(),
-  query_field: Joi.string().valid(['_id', 'username']),
-  fields: Joi.any(),
   include: Joi.any()
 };

--- a/models/validations/event.joi.js
+++ b/models/validations/event.joi.js
@@ -1,6 +1,15 @@
 const Joi = require('joi');
 
-const { limit, skip, id, fields, include } = require('./common.joi');
+const { limit, skip, id, include } = require('./common.joi');
+
+const fields = Joi.object().keys({
+  self: Joi.array()
+    .items(Joi.string())
+    .single(),
+  _questions: Joi.array()
+    .items(Joi.string().invalid('answer'))
+    .single()
+});
 
 const list = (() => {
   const base = {
@@ -21,7 +30,7 @@ const get = (() => {
     id,
     fields,
     include,
-    query_field: Joi.string()
+    query_field: Joi.string().valid(['_id', 'name'])
   };
   return {
     public: Joi.object(base),

--- a/models/validations/question.joi.js
+++ b/models/validations/question.joi.js
@@ -1,6 +1,15 @@
 const Joi = require('joi');
 
-const { limit, skip, id, fields, include } = require('./common.joi');
+const { limit, skip, id, include } = require('./common.joi');
+
+const fields = Joi.object().keys({
+  self: Joi.array()
+    .items(Joi.string().invalid('answer'))
+    .single(),
+  _event: Joi.array()
+    .items(Joi.string().invalid('_question'))
+    .single()
+});
 
 const list = (() => {
   const base = {

--- a/models/validations/user.joi.js
+++ b/models/validations/user.joi.js
@@ -1,8 +1,19 @@
 const Joi = require('joi');
 
-const { limit, skip, id, query_field } = require('./common.joi');
+const { limit, skip, id } = require('./common.joi');
+
+const query_field = Joi.string().valid(['_id', 'username']);
 
 const preset = Joi.string().valid(['profile', 'imp', 'short']);
+
+// const field = Joi.array().items(Joi.string()).single();
+
+// const fields = Joi.object().keys({
+//   self: field,
+//   _society: field,
+//   _arena: field
+// })
+
 const fields = Joi.string();
 
 const list = (() => {

--- a/services/question.service.js
+++ b/services/question.service.js
@@ -1,9 +1,13 @@
 const Question = require('mongoose').model('Question');
+const _isString = require('lodash/isString');
 
 const EventService = require('./event.service.js');
 
 const getPopulations = ({ include = [], fields = {} }) => {
   const allowedIncludes = ['_event'];
+  if (_isString(include)) {
+    include = [include];
+  }
   include = allowedIncludes.filter(allowedField => include.includes(allowedField)); //to check valid include
   return include.map(includedField => ({ path: includedField, select: fields[includedField] }));
 };

--- a/services/question.service.js
+++ b/services/question.service.js
@@ -1,13 +1,9 @@
 const Question = require('mongoose').model('Question');
-const _isString = require('lodash/isString');
 
 const EventService = require('./event.service.js');
 
 const getPopulations = ({ include = [], fields = {} }) => {
   const allowedIncludes = ['_event'];
-  if (_isString(include)) {
-    include = [include];
-  }
   include = allowedIncludes.filter(allowedField => include.includes(allowedField)); //to check valid include
   return include.map(includedField => ({ path: includedField, select: fields[includedField] }));
 };

--- a/tests/event.test.js
+++ b/tests/event.test.js
@@ -13,7 +13,7 @@ module.exports = test => {
       skip: 0,
       fields: {
         self: ['name', 'winners'],
-        _questions: ['answer']
+        _questions: ['text']
       },
       include: ['_questions']
     }).end((err, { body: eventList }) => {
@@ -28,7 +28,7 @@ module.exports = test => {
               .items(
                 Joi.object().keys({
                   _id: Joi.string().required(),
-                  answer: Joi.string().required()
+                  text: Joi.string().required()
                 })
               )
               .required()


### PR DESCRIPTION
**Important**

In the event joi schema, for fields object, the _question key has answer as an invalid value. This prevents a client from getting an answer.

But still if no field is specified in request then complete data is exposed (including answer key).

Currently **question** api is available to admin, but the **event** api is public exposed. 
if we do `/api/events?limit=2&skip=0&include=_questions` then questions data is also included which has answer field, so remember to check all apis include field also